### PR TITLE
use https api

### DIFF
--- a/src/main/java/org/lantern/exceptional4j/ExceptionalAppender.java
+++ b/src/main/java/org/lantern/exceptional4j/ExceptionalAppender.java
@@ -236,7 +236,7 @@ public class ExceptionalAppender extends AppenderSkeleton {
         System.out.println("Submitting data...");
         final DefaultHttpClient httpclient = new DefaultHttpClient();
 
-        final String url = "http://api.getexceptional.com/api/errors?" +
+        final String url = "https://www.exceptional.io/api/errors?" +
             "api_key="+this.apiKey+"&protocol_version=6";
         final HttpPost post = new HttpPost(url);
         post.setHeader(HttpHeaders.CONTENT_ENCODING, "gzip");


### PR DESCRIPTION
Quoting Ben Arent from Exceptional:

> Please point it to https://www.exceptional.io . This has a wildcard SSL and support SSL.

Just changed the url with blind faith. Some way we can test before merging the patch upstream?
